### PR TITLE
GitHub Edit Link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 node_modules
 generated-language-mapping.json
 token.md
+_posts/*

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -15,7 +15,8 @@
 
         <main id="main" class="main">
           {% unless page.no_header %}
-            <aside class="improve-page"><a href="{{ site.docs_github }}/edit/master/{{ page.dir }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
+          {% assign paths = page.path | split: "/" %}
+            <aside class="improve-page"><a href="{{ site.docs_github }}/edit/master/{{ paths[1] }}/{{ page.name }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
             <h1 class="title">{{ page.title }}</h1>
           {% endunless %}
           {{ content }}

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -15,7 +15,7 @@
 
         <main id="main" class="main">
           {% unless page.no_header %}
-            <aside class="improve-page"><a href="{{ site.docs_github }}/edit/master/{{ page.path }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
+            <aside class="improve-page"><a href="{{ site.docs_github }}/edit/master/{{ page.dir }}/{{ page.name }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
             <h1 class="title">{{ page.title }}</h1>
           {% endunless %}
           {{ content }}

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -15,7 +15,7 @@
 
         <main id="main" class="main">
           {% unless page.no_header %}
-            <aside class="improve-page"><a href="{{ site.docs_github }}/edit/master/{{ page.dir }}/{{ page.name }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
+            <aside class="improve-page"><a href="{{ site.docs_github }}/edit/master/{{ page.dir }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
             <h1 class="title">{{ page.title }}</h1>
           {% endunless %}
           {{ content }}


### PR DESCRIPTION
Remove the `/posts` folder from the edit link.